### PR TITLE
Add Home Assistant coordinator and tests

### DIFF
--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,0 +1,1 @@
+"""Home Assistant custom component namespace for Ultimate Govee."""

--- a/custom_components/ultimate_govee/__init__.py
+++ b/custom_components/ultimate_govee/__init__.py
@@ -1,0 +1,15 @@
+"""Ultimate Govee Home Assistant integration package."""
+
+from .coordinator import (
+    CommandRequest,
+    DeviceMetadata,
+    EntityMetadata,
+    UltimateGoveeCoordinator,
+)
+
+__all__ = [
+    "CommandRequest",
+    "DeviceMetadata",
+    "EntityMetadata",
+    "UltimateGoveeCoordinator",
+]

--- a/custom_components/ultimate_govee/coordinator.py
+++ b/custom_components/ultimate_govee/coordinator.py
@@ -1,0 +1,270 @@
+"""Coordinator layer bridging Ultimate Govee with Home Assistant constructs."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any, Awaitable, Callable, Dict, Mapping, MutableMapping, Optional
+
+ChannelMessage = Dict[str, Any]
+ScheduleCallback = Callable[[timedelta, Callable[[], Awaitable[Any]]], Callable[[], None]]
+
+
+@dataclass(frozen=True)
+class EntityMetadata:
+    """Description of an entity exposed for a device."""
+
+    entity_id: str
+    unique_id: str
+    platform: str
+    translation_key: str
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DeviceMetadata:
+    """Metadata returned from the Ultimate Govee API describing a device."""
+
+    device_id: str
+    name: str
+    model: str
+    manufacturer: str
+    hw_version: str
+    sw_version: str
+    channels: Dict[str, Dict[str, Any]]
+    entities: list[EntityMetadata]
+    default_transport: Optional[str] = None
+
+    @property
+    def preferred_transport(self) -> Optional[str]:
+        """Return the preferred transport for the device."""
+
+        if self.default_transport:
+            return self.default_transport
+        if self.channels:
+            return next(iter(self.channels.keys()))
+        return None
+
+
+@dataclass(frozen=True)
+class CommandRequest:
+    """Representation of a command routed via the coordinator."""
+
+    transport: Optional[str]
+    payload: Dict[str, Any]
+
+
+class _CoordinatedDevice:
+    """Runtime state wrapper for a discovered device."""
+
+    def __init__(self, metadata: DeviceMetadata):
+        self.metadata = metadata
+        self.state: Dict[str, Any] = {}
+
+    @property
+    def id(self) -> str:
+        return self.metadata.device_id
+
+    @property
+    def preferred_transport(self) -> Optional[str]:
+        return self.metadata.preferred_transport
+
+    async def async_refresh(self, api_client: Any) -> Dict[str, Any]:
+        """Refresh device state via the provided API client."""
+
+        state = await api_client.async_get_device_state(self.id)
+        if isinstance(state, Mapping):
+            self.state.update(state)  # type: ignore[arg-type]
+        return self.state
+
+    def apply_event(self, channel: str, message: ChannelMessage) -> None:
+        """Apply an incoming event payload to the in-memory state."""
+
+        state = message.get("state")
+        if isinstance(state, Mapping):
+            self.state.update(state)  # type: ignore[arg-type]
+
+
+class DataUpdateCoordinator:
+    """Minimal stand-in for Home Assistant's DataUpdateCoordinator."""
+
+    def __init__(
+        self,
+        *,
+        update_interval: timedelta,
+        schedule_refresh: Optional[ScheduleCallback] = None,
+    ) -> None:
+        self.update_interval = update_interval
+        self._schedule_refresh = schedule_refresh
+        self._cancel_refresh: Optional[Callable[[], None]] = None
+        self._periodic_task: Optional[asyncio.Task[None]] = None
+        self._started = False
+        self.data: Any = None
+
+    async def async_start(self) -> None:
+        """Begin periodic refresh operations."""
+
+        if self._started or self.update_interval.total_seconds() <= 0:
+            self._started = True
+            return
+
+        self._started = True
+        if self._schedule_refresh is not None:
+            self._cancel_refresh = self._schedule_refresh(
+                self.update_interval, self.async_refresh
+            )
+            return
+
+        loop = asyncio.get_running_loop()
+        self._periodic_task = loop.create_task(self._run_periodic())
+
+    async def _run_periodic(self) -> None:
+        try:
+            while self._started:
+                await asyncio.sleep(self.update_interval.total_seconds())
+                await self.async_refresh()
+        except asyncio.CancelledError:
+            pass
+
+    async def async_refresh(self) -> Any:
+        """Fetch fresh data from the underlying source."""
+
+        self.data = await self._async_update_data()
+        return self.data
+
+    async def _async_update_data(self) -> Any:
+        raise NotImplementedError
+
+    async def async_stop(self) -> None:
+        """Cancel ongoing refresh timers."""
+
+        if not self._started:
+            return
+
+        self._started = False
+        if self._cancel_refresh is not None:
+            self._cancel_refresh()
+            self._cancel_refresh = None
+
+        if self._periodic_task:
+            self._periodic_task.cancel()
+            try:
+                await self._periodic_task
+            except asyncio.CancelledError:
+                pass
+            self._periodic_task = None
+
+
+class UltimateGoveeCoordinator(DataUpdateCoordinator):
+    """Owns Ultimate Govee devices and bridges channel events with HA."""
+
+    def __init__(
+        self,
+        *,
+        hass: Any,
+        config_entry_id: str,
+        api_client: Any,
+        channels: Mapping[str, Any],
+        device_registry: Any,
+        entity_registry: Any,
+        update_interval: timedelta,
+        schedule_refresh: Optional[ScheduleCallback] = None,
+    ) -> None:
+        super().__init__(update_interval=update_interval, schedule_refresh=schedule_refresh)
+        self.hass = hass
+        self._config_entry_id = config_entry_id
+        self._api_client = api_client
+        self._channels = channels
+        self._device_registry = device_registry
+        self._entity_registry = entity_registry
+        self.devices: MutableMapping[str, _CoordinatedDevice] = {}
+        self._subscriptions_bound = False
+
+    async def async_initialize(self) -> None:
+        """Discover devices from the API and register them with HA registries."""
+
+        self._ensure_channel_subscriptions()
+        discovered: list[DeviceMetadata] = list(
+            await self._api_client.async_list_devices()
+        )
+        for metadata in discovered:
+            await self._register_device(metadata)
+        await self.async_start()
+
+    async def async_execute_command(
+        self, device_id: str, command: CommandRequest
+    ) -> None:
+        """Publish commands to the proper transport for the device."""
+
+        if device_id not in self.devices:
+            raise KeyError(f"Unknown device: {device_id}")
+
+        transport = command.transport or self.devices[device_id].preferred_transport
+        if not transport:
+            raise ValueError(f"No transport available for device {device_id}")
+
+        channel = self._channels.get(transport)
+        if channel is None:
+            raise ValueError(f"Transport {transport} is not configured")
+
+        await channel.async_send_command(device_id, command.payload)
+
+    async def _async_update_data(self) -> Dict[str, Dict[str, Any]]:
+        """Refresh state for all registered devices."""
+
+        updated: Dict[str, Dict[str, Any]] = {}
+        for device_id, device in self.devices.items():
+            updated[device_id] = await device.async_refresh(self._api_client)
+        return updated
+
+    async def async_stop(self) -> None:  # type: ignore[override]
+        await super().async_stop()
+
+    def _ensure_channel_subscriptions(self) -> None:
+        if self._subscriptions_bound:
+            return
+        for name, channel in self._channels.items():
+            if hasattr(channel, "subscribe"):
+                channel.subscribe(self._handle_channel_event)
+        self._subscriptions_bound = True
+
+    async def _register_device(self, metadata: DeviceMetadata) -> None:
+        device_entry = await self._device_registry.async_get_or_create(
+            config_entry_id=self._config_entry_id,
+            identifiers={("ultimate_govee", metadata.device_id)},
+            manufacturer=metadata.manufacturer,
+            name=metadata.name,
+            model=metadata.model,
+            sw_version=metadata.sw_version,
+            hw_version=metadata.hw_version,
+        )
+        for entity in metadata.entities:
+            await self._entity_registry.async_get_or_create(
+                config_entry=self._config_entry_id,
+                unique_id=entity.unique_id,
+                platform=entity.platform,
+                entity_id=entity.entity_id,
+                translation_key=entity.translation_key,
+                device_id=device_entry["id"],
+                **entity.extra,
+            )
+        device = _CoordinatedDevice(metadata)
+        self.devices[metadata.device_id] = device
+
+    def _handle_channel_event(self, channel: str, message: ChannelMessage) -> None:
+        device_id = message.get("device_id")
+        if not device_id:
+            return
+        device = self.devices.get(device_id)
+        if device is None:
+            return
+        device.apply_event(channel, message)
+
+
+__all__ = [
+    "CommandRequest",
+    "DeviceMetadata",
+    "EntityMetadata",
+    "UltimateGoveeCoordinator",
+]

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for Ultimate Govee integration tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/pytests/test_coordinator.py
+++ b/pytests/test_coordinator.py
@@ -1,0 +1,300 @@
+import asyncio
+from datetime import timedelta
+from typing import Any, Callable, Dict, List
+
+
+class FakeApiClient:
+    def __init__(self, devices: List[Any], states: Dict[str, Dict[str, Any]]):
+        self._devices = devices
+        self._states = states
+        self.list_calls: int = 0
+        self.state_calls: List[str] = []
+
+    async def async_list_devices(self) -> List[Any]:
+        self.list_calls += 1
+        return self._devices
+
+    async def async_get_device_state(self, device_id: str) -> Dict[str, Any]:
+        self.state_calls.append(device_id)
+        return self._states.get(device_id, {})
+
+
+class FakeDeviceRegistry:
+    def __init__(self):
+        self.created: List[Dict[str, Any]] = []
+
+    async def async_get_or_create(self, **data: Any) -> Dict[str, Any]:
+        self.created.append(data)
+        return {"id": f"device-{len(self.created)}", **data}
+
+
+class FakeEntityRegistry:
+    def __init__(self):
+        self.registered: List[Dict[str, Any]] = []
+
+    async def async_get_or_create(self, **data: Any) -> Dict[str, Any]:
+        self.registered.append(data)
+        return {"entity_id": data.get("entity_id", f"entity.{len(self.registered)}"), **data}
+
+
+class FakeChannel:
+    def __init__(self, name: str):
+        self.name = name
+        self.listeners: List[Callable[[str, Dict[str, Any]], None]] = []
+        self.commands: List[Dict[str, Any]] = []
+
+    def subscribe(self, callback: Callable[[str, Dict[str, Any]], None]) -> None:
+        self.listeners.append(callback)
+
+    async def async_send_command(self, device_id: str, payload: Dict[str, Any]) -> None:
+        self.commands.append({"device_id": device_id, "payload": payload, "channel": self.name})
+
+    def emit(self, device_id: str, payload: Dict[str, Any]) -> None:
+        for listener in list(self.listeners):
+            listener(self.name, {"device_id": device_id, **payload})
+
+
+class FakeHass:
+    def __init__(self):
+        self.data: Dict[str, Any] = {}
+
+
+def test_coordinator_discovers_devices_and_registers_entities() -> None:
+    async def run() -> None:
+        from custom_components.ultimate_govee.coordinator import (
+            DeviceMetadata,
+            EntityMetadata,
+            UltimateGoveeCoordinator,
+        )
+
+        api = FakeApiClient(
+            [
+                DeviceMetadata(
+                    device_id="dev-1",
+                    name="Office Light",
+                    model="H6001",
+                    manufacturer="Govee",
+                    hw_version="1.0",
+                    sw_version="2.0",
+                    channels={"iot": {"topic": "light/dev-1"}},
+                    entities=[
+                        EntityMetadata(
+                            entity_id="light.office",
+                            unique_id="dev-1-light",
+                            platform="light",
+                            translation_key="office_light",
+                        )
+                    ],
+                ),
+                DeviceMetadata(
+                    device_id="dev-2",
+                    name="Desk Fan",
+                    model="H7101",
+                    manufacturer="Govee",
+                    hw_version="1.1",
+                    sw_version="2.1",
+                    channels={"ble": {"mac": "AA:BB:CC:DD:EE:FF"}},
+                    entities=[
+                        EntityMetadata(
+                            entity_id="fan.desk",
+                            unique_id="dev-2-fan",
+                            platform="fan",
+                            translation_key="desk_fan",
+                        )
+                    ],
+                ),
+            ],
+            states={"dev-1": {"on": False}, "dev-2": {"speed": "medium"}},
+        )
+        device_registry = FakeDeviceRegistry()
+        entity_registry = FakeEntityRegistry()
+        channels = {"iot": FakeChannel("iot"), "ble": FakeChannel("ble")}
+
+        scheduled: List[Dict[str, Any]] = []
+
+        def schedule_refresh(
+            interval: timedelta, callback: Callable[[], Any]
+        ) -> Callable[[], None]:
+            scheduled.append({"interval": interval, "callback": callback})
+
+            def cancel() -> None:
+                scheduled.append({"cancelled": True})
+
+            return cancel
+
+        coordinator = UltimateGoveeCoordinator(
+            hass=FakeHass(),
+            config_entry_id="config-1",
+            api_client=api,
+            channels=channels,
+            device_registry=device_registry,
+            entity_registry=entity_registry,
+            update_interval=timedelta(seconds=30),
+            schedule_refresh=schedule_refresh,
+        )
+
+        await coordinator.async_initialize()
+
+        assert set(coordinator.devices.keys()) == {"dev-1", "dev-2"}
+        assert api.list_calls == 1
+        assert device_registry.created[0]["identifiers"] == {("ultimate_govee", "dev-1")}
+        assert entity_registry.registered[0]["unique_id"] == "dev-1-light"
+
+        channels["iot"].emit("dev-1", {"state": {"on": True}})
+        await asyncio.sleep(0)
+
+        assert coordinator.devices["dev-1"].state["on"] is True
+
+        await coordinator.async_stop()
+        assert scheduled[-1].get("cancelled") is True
+
+    asyncio.run(run())
+
+
+def test_commands_route_to_expected_transport() -> None:
+    async def run() -> None:
+        from custom_components.ultimate_govee.coordinator import (
+            CommandRequest,
+            DeviceMetadata,
+            EntityMetadata,
+            UltimateGoveeCoordinator,
+        )
+
+        metadata = [
+            DeviceMetadata(
+                device_id="dev-1",
+                name="Office Light",
+                model="H6001",
+                manufacturer="Govee",
+                hw_version="1.0",
+                sw_version="2.0",
+                channels={"iot": {}},
+                entities=[
+                    EntityMetadata(
+                        entity_id="light.office",
+                        unique_id="dev-1-light",
+                        platform="light",
+                        translation_key="office_light",
+                    )
+                ],
+            )
+        ]
+        api = FakeApiClient(metadata, states={})
+        device_registry = FakeDeviceRegistry()
+        entity_registry = FakeEntityRegistry()
+        channels = {"iot": FakeChannel("iot"), "ble": FakeChannel("ble")}
+
+        coordinator = UltimateGoveeCoordinator(
+            hass=FakeHass(),
+            config_entry_id="config-1",
+            api_client=api,
+            channels=channels,
+            device_registry=device_registry,
+            entity_registry=entity_registry,
+            update_interval=timedelta(seconds=15),
+        )
+
+        await coordinator.async_initialize()
+
+        await coordinator.async_execute_command(
+            "dev-1", CommandRequest(transport="iot", payload={"cmd": "turn_on"})
+        )
+
+        assert channels["iot"].commands == [
+            {"device_id": "dev-1", "payload": {"cmd": "turn_on"}, "channel": "iot"}
+        ]
+
+    asyncio.run(run())
+
+
+def test_refresh_scheduling_calls_refresh_for_all_devices() -> None:
+    async def run() -> None:
+        from custom_components.ultimate_govee.coordinator import (
+            DeviceMetadata,
+            EntityMetadata,
+            UltimateGoveeCoordinator,
+        )
+
+        metadata = [
+            DeviceMetadata(
+                device_id="dev-1",
+                name="Office Light",
+                model="H6001",
+                manufacturer="Govee",
+                hw_version="1.0",
+                sw_version="2.0",
+                channels={"iot": {}},
+                entities=[
+                    EntityMetadata(
+                        entity_id="light.office",
+                        unique_id="dev-1-light",
+                        platform="light",
+                        translation_key="office_light",
+                    )
+                ],
+            ),
+            DeviceMetadata(
+                device_id="dev-2",
+                name="Desk Fan",
+                model="H7101",
+                manufacturer="Govee",
+                hw_version="1.1",
+                sw_version="2.1",
+                channels={"ble": {}},
+                entities=[
+                    EntityMetadata(
+                        entity_id="fan.desk",
+                        unique_id="dev-2-fan",
+                        platform="fan",
+                        translation_key="desk_fan",
+                    )
+                ],
+            ),
+        ]
+        api = FakeApiClient(
+            metadata, states={"dev-1": {"on": True}, "dev-2": {"speed": "high"}}
+        )
+        device_registry = FakeDeviceRegistry()
+        entity_registry = FakeEntityRegistry()
+        channels = {"iot": FakeChannel("iot"), "ble": FakeChannel("ble")}
+
+        cancel_calls: List[None] = []
+        captured_interval: List[timedelta] = []
+        refresh_callbacks: List[Callable[[], Any]] = []
+
+        def schedule_refresh(
+            interval: timedelta, callback: Callable[[], Any]
+        ) -> Callable[[], None]:
+            captured_interval.append(interval)
+            refresh_callbacks.append(callback)
+
+            def cancel() -> None:
+                cancel_calls.append(None)
+
+            return cancel
+
+        coordinator = UltimateGoveeCoordinator(
+            hass=FakeHass(),
+            config_entry_id="config-1",
+            api_client=api,
+            channels=channels,
+            device_registry=device_registry,
+            entity_registry=entity_registry,
+            update_interval=timedelta(seconds=45),
+            schedule_refresh=schedule_refresh,
+        )
+
+        await coordinator.async_initialize()
+        await coordinator.async_start()
+
+        assert captured_interval == [timedelta(seconds=45)]
+
+        await refresh_callbacks[0]()
+
+        assert sorted(api.state_calls) == ["dev-1", "dev-2"]
+        assert coordinator.devices["dev-2"].state["speed"] == "high"
+
+        await coordinator.async_stop()
+        assert cancel_calls, "Stop should cancel the scheduled refresh"
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add coordinator-focused integration tests covering discovery, command routing, and scheduled refresh handling
- implement a Home Assistant-style Ultimate Govee coordinator that registers devices/entities and routes events
- configure pytest to load the new custom component package

## Testing
- npm run lint *(fails: ESLint configuration missing in repo)*
- npm run test *(fails: Nest CLI not installed in environment)*
- pytest pytests/test_coordinator.py

------
https://chatgpt.com/codex/tasks/task_e_68fcb82794148328952e7e05c3dc3448